### PR TITLE
Add research notes on Berlin situation on 19 April 1945

### DIFF
--- a/docs/berlin_status_1945-04-19.md
+++ b/docs/berlin_status_1945-04-19.md
@@ -1,0 +1,22 @@
+# Berlin Situation as of 19 April 1945
+
+## Overview
+- Soviet forces of the 1st Belorussian Front broke through the Seelow Heights defenses on 19 April, pushing the German 9th Army back toward Berlin and exposing the outer defensive ring of the city.
+- The 1st Ukrainian Front advanced northward, seizing key command centers such as Zossen and the headquarters of the German Army High Command (OKH), further isolating Berlin from southern reinforcements.
+- By the evening, Soviet spearheads had reached towns 30–40 km southeast and south of Berlin (e.g., Königs Wusterhausen, Baruth), collapsing the German "Wotan" defensive line and leaving only urban fortifications between the Red Army and the capital.
+
+## Front Line & Encirclement Status
+- Eastern Approaches: After the fall of the Seelow Heights, Soviet units established bridgeheads across the Oder-Spree Canal, allowing armor and artillery to roll west toward the city districts of Marzahn and Lichtenberg.
+- Southern Approaches: The 3rd and 4th Guards Tank Armies captured Zossen (seat of OKH communications bunkers) and encircled large portions of the German 9th Army south of Berlin near Halbe.
+- Northern Approaches: Elements of the 2nd Belorussian Front forced the Finow Canal near Eberswalde, threatening Berlin's northern flank even though they had not yet reached the city's outskirts.
+
+## German Defensive Measures
+- General Helmuth Weidling assumed command of Berlin's defenses, reorganizing the city's remaining formations into improvised battle groups and Volkssturm units.
+- Orders were issued to withdraw surviving units from the Oder front into the Berlin Defense Area, but many formations were trapped or destroyed during the retreat, reducing available manpower and armor inside the city.
+
+## Implications for Visualization
+- **High-risk zones** (recommend warm colors): southeastern and southern sectors (Treptow, Neukölln, Tempelhof) where Soviet armored spearheads were expected within 24 hours.
+- **Contested buffer** (recommend transitional hues): eastern districts (Lichtenberg, Friedrichshain) where forward Soviet artillery positions began shelling the city proper.
+- **Lower-pressure zones** (recommend cooler colors): western suburbs, still outside immediate Soviet reach on 19 April but facing imminent encirclement as northern and southern pincers converged.
+
+These findings can guide a color-filter overlay showing gradients of Soviet pressure radiating from the east and south toward central Berlin.


### PR DESCRIPTION
## Summary
- document the Soviet encirclement status of Berlin on 19 April 1945
- outline German defensive measures and implications for visualization overlays

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5aa20ffe48331a95fbfc41595ac3e